### PR TITLE
Corrected type conversion in C file

### DIFF
--- a/opencv/opencv.c
+++ b/opencv/opencv.c
@@ -14,8 +14,8 @@
 
 // trackbar data
 struct TrackbarUserdata {
-	schar* win_name;
-	schar* bar_name;
+	char* win_name;
+	char* bar_name;
 	int value;
 };
 static struct TrackbarUserdata *trackbar_list[1000];
@@ -32,8 +32,8 @@ int GoOpenCV_CreateTrackbar(
 	struct TrackbarUserdata *userdata = malloc(sizeof(*userdata));
 	trackbar_list[trackbar_list_len++] = userdata;
 
-	userdata->win_name = (schar*)window_name;
-	userdata->bar_name = (schar*)trackbar_name;
+	userdata->win_name = (char*)window_name;
+	userdata->bar_name = (char*)trackbar_name;
 	userdata->value = value;
 
 	return cvCreateTrackbar2(trackbar_name, window_name,
@@ -58,7 +58,7 @@ void GoOpenCV_DestroyTrackbar(char* trackbar_name, char* window_name) {
 //-----------------------------------------------------------------------------
 
 static void mouseCallback(int event, int x, int y, int flags, void* param) {
-	schar* name = (schar*)param;
+	char* name = (char*)param;
 	goMouseCallback(name, event, x, y, flags);
 }
 void GoOpenCV_SetMouseCallback(const char* window_name) {


### PR DESCRIPTION
On my Mac (10.9.1) `go run <any_example>` it shown warnings:

``` sh
src/github.com/saratovsource/go-opencv/opencv/opencv.c:26:21: warning: passing 'schar *' (aka 'signed char *') to parameter of type 'char *' converts between pointers to integer types with different sign [-Wpointer-sign]
src/github.com/saratovsource/go-opencv/opencv/highgui.go:37:38: note: passing argument to parameter 'p0' here
src/github.com/saratovsource/go-opencv/opencv/opencv.c:26:36: warning: passing 'schar *' (aka 'signed char *') to parameter of type 'char *' converts between pointers to integer types with different sign [-Wpointer-sign]
src/github.com/saratovsource/go-opencv/opencv/highgui.go:37:48: note: passing argument to parameter 'p1' here
src/github.com/saratovsource/go-opencv/opencv/opencv.c:62:18: warning: passing 'schar *' (aka 'signed char *') to parameter of type 'char *' converts between pointers to integer types with different sign [-Wpointer-sign]
src/github.com/saratovsource/go-opencv/opencv/highgui.go:39:35: note: passing argument to parameter 'p0' here
```

I tried to make the same types in C file and warnings stopped output.
Can you test it in your environments?
