### PR TITLE
Stop DecodeImageMem memory leak

### DIFF
--- a/opencv/goimage.go
+++ b/opencv/goimage.go
@@ -10,6 +10,7 @@ import (
 func DecodeImageMem(data []byte) *IplImage {
 	buf := CreateMatHeader(1, len(data), CV_8U)
 	buf.SetData(unsafe.Pointer(&data[0]), CV_AUTOSTEP)
+	defer buf.Release()
 
 	return DecodeImage(unsafe.Pointer(buf), CV_LOAD_IMAGE_UNCHANGED)
 }


### PR DESCRIPTION
The `DecodeImageMem` function creates a header. This header needs to be freed before the return the image. The header wasn't being freed, so this function had a memory leak.
