### PR TITLE
make FromImage work with gifs

### DIFF
--- a/opencv/cvaux.go
+++ b/opencv/cvaux.go
@@ -69,10 +69,10 @@ func (this *HaarCascade) DetectObjects(image *IplImage) []*Rect {
 		rect := (*Rect)((*_Ctype_CvRect)(unsafe.Pointer(C.cvGetSeqElem(seq, C.int(i)))))
 		faces = append(faces, rect)
 	}
-	
+
 	storage_c := (*C.CvMemStorage)(storage)
 	C.cvReleaseMemStorage(&storage_c)
-	
+
 	return faces
 }
 

--- a/opencv/goimage.go
+++ b/opencv/goimage.go
@@ -30,7 +30,7 @@ func FromImage(img image.Image) *IplImage {
 			c := model.Convert(px).(color.RGBA)
 
 			value := NewScalar(float64(c.B), float64(c.G), float64(c.R), float64(c.A))
-			dst.Set2D(x, y, value)
+			dst.Set2D(x-b.Min.X, y-b.Min.Y, value)
 		}
 	}
 


### PR DESCRIPTION
FromImage crashes when trying to process an image like this: http://i.imgur.com/EolEXZu.gif

This issue occurs when `b.Min.X` and `b.Min.Y` are not zero. With this change, the gif gets loaded correctly.
