### PR TITLE
changed ApproxPoly to allocate its own CvMemStorage

### DIFF
--- a/opencv/imgproc.go
+++ b/opencv/imgproc.go
@@ -123,11 +123,13 @@ func DrawContours(image *IplImage, contours *Seq, externalColor, holeColor Scala
 }
 
 // CvSeq* cvApproxPoly(const void* src_seq, int header_size, CvMemStorage* storage, int method, double eps, int recursive=0 )
-func ApproxPoly(src *Seq, header_size int, storage *MemStorage, method int, eps float64, recursive int) *Seq {
+func ApproxPoly(src *Seq, method int, eps float64, recursive int) *Seq {
+	storage := C.cvCreateMemStorage(0)
+	header_size := (C.size_t)(unsafe.Sizeof(C.CvContour{}))
 	seq := C.cvApproxPoly(
 		unsafe.Pointer(src),
 		C.int(header_size),
-		(*C.CvMemStorage)(storage),
+		storage,
 		C.int(method),
 		C.double(eps),
 		C.int(recursive))


### PR DESCRIPTION
Did not see an exported method to allocate CvMemStorage so modified ApproxPoly to allocate its own memory and header size like FindContours. 