### PR TITLE
Allow use of pkg-config on Windows via tag

### DIFF
--- a/opencv/cluster.go
+++ b/opencv/cluster.go
@@ -5,10 +5,6 @@
 package opencv
 
 //#include "opencv.h"
-//#cgo linux  pkg-config: opencv
-//#cgo darwin pkg-config: opencv
-//#cgo freebsd pkg-config: opencv
-//#cgo windows LDFLAGS: -lopencv_core242.dll -lopencv_imgproc242.dll -lopencv_photo242.dll -lopencv_highgui242.dll -lstdc++
 import "C"
 import "unsafe"
 

--- a/opencv/cv.go
+++ b/opencv/cv.go
@@ -8,7 +8,8 @@ package opencv
 //#cgo linux  pkg-config: opencv
 //#cgo darwin pkg-config: opencv
 //#cgo freebsd pkg-config: opencv
-//#cgo windows LDFLAGS: -lopencv_core242.dll -lopencv_imgproc242.dll -lopencv_photo242.dll -lopencv_highgui242.dll -lstdc++
+//#cgo windows,pkgconfig pkg-config: opencv
+//#cgo windows,!pkgconfig LDFLAGS: -lopencv_core242.dll -lopencv_imgproc242.dll -lopencv_photo242.dll -lopencv_highgui242.dll -lstdc++
 import "C"
 import (
 	//"errors"

--- a/opencv/cvaux.go
+++ b/opencv/cvaux.go
@@ -5,10 +5,6 @@
 package opencv
 
 //#include "opencv.h"
-//#cgo linux  pkg-config: opencv
-//#cgo darwin pkg-config: opencv
-//#cgo freebsd pkg-config: opencv
-//#cgo windows LDFLAGS: -lopencv_core242.dll -lopencv_imgproc242.dll -lopencv_photo242.dll -lopencv_highgui242.dll -lstdc++
 import "C"
 import (
 	"unsafe"
@@ -68,7 +64,7 @@ func (this *HaarCascade) DetectObjects(image *IplImage) []*Rect {
 	var faces []*Rect
 	for i := 0; i < (int)(seq.total); i++ {
 		rect := (*Rect)((*_Ctype_CvRect)(unsafe.Pointer(C.cvGetSeqElem(seq, C.int(i)))))
-		rectgc := NewRect(rect.X(),rect.Y(),rect.Width(),rect.Height())
+		rectgc := NewRect(rect.X(), rect.Y(), rect.Width(), rect.Height())
 		faces = append(faces, &rectgc)
 	}
 

--- a/opencv/cxcore.go
+++ b/opencv/cxcore.go
@@ -5,10 +5,6 @@
 package opencv
 
 //#include "opencv.h"
-//#cgo linux  pkg-config: opencv
-//#cgo darwin pkg-config: opencv
-//#cgo freebsd pkg-config: opencv
-//#cgo windows LDFLAGS: -lopencv_core242.dll -lopencv_imgproc242.dll -lopencv_photo242.dll -lopencv_highgui242.dll -lstdc++
 import "C"
 import (
 	//"errors"

--- a/opencv/cxtype.go
+++ b/opencv/cxtype.go
@@ -5,16 +5,6 @@
 package opencv
 
 /*
-#cgo linux  pkg-config: opencv
-// Add the math library link on arm, as opencv is built without gl support on
-// debian and ubuntu. This one is thus using lrint which is in the math library.
-// The pkg-config arm file doesn't add it though.
-// Workaround it here until fixed in the distros.
-#cgo linux,arm linux,arm64 LDFLAGS: -lm
-#cgo darwin pkg-config: opencv
-#cgo freebsd pkg-config: opencv
-#cgo windows LDFLAGS: -lopencv_core242.dll -lopencv_imgproc242.dll -lopencv_photo242.dll -lopencv_highgui242.dll -lstdc++
-
 #include "opencv.h"
 #include <stdlib.h>
 #include <string.h>

--- a/opencv/highgui.go
+++ b/opencv/highgui.go
@@ -5,10 +5,6 @@
 package opencv
 
 //#include "opencv.h"
-//#cgo linux  pkg-config: opencv
-//#cgo darwin pkg-config: opencv
-//#cgo freebsd pkg-config: opencv
-//#cgo windows LDFLAGS: -lopencv_core242.dll -lopencv_imgproc242.dll -lopencv_photo242.dll -lopencv_highgui242.dll -lstdc++
 import "C"
 import (
 	_ "fmt"

--- a/opencv/imgproc.go
+++ b/opencv/imgproc.go
@@ -5,10 +5,6 @@
 package opencv
 
 //#include "opencv.h"
-//#cgo linux  pkg-config: opencv
-//#cgo darwin pkg-config: opencv
-//#cgo freebsd pkg-config: opencv
-//#cgo windows LDFLAGS: -lopencv_core242.dll -lopencv_imgproc242.dll -lopencv_photo242.dll -lopencv_highgui242.dll -lstdc++
 import "C"
 import (
 	//"errors"


### PR DESCRIPTION
With this change #cgo directions are used only in file cv.go, no need to duplicate this in every file since that makes it much harder to maintain or change something.

Now on Windows `-tags pkgconfig` can be used to use pkg-config instead of hard coded libraries with version. It is useful when you want to cross compile Windows binary in Linux with mingw-w64, and it is easier to modify .pc file if needed then to modify Go code directly. 