### PR TITLE
Change mangled C name to current Cgo naming format.

### DIFF
--- a/opencv/cv.go
+++ b/opencv/cv.go
@@ -6,7 +6,7 @@ package opencv
 
 //#include "opencv.h"
 //#cgo linux  pkg-config: opencv
-//#cgo darwin pkg-config: opencv
+//#cgo darwin LDFLAGS: -framework opencv2.framework
 //#cgo freebsd pkg-config: opencv
 //#cgo windows,pkgconfig pkg-config: opencv
 //#cgo windows,!pkgconfig LDFLAGS: -lopencv_core242.dll -lopencv_imgproc242.dll -lopencv_photo242.dll -lopencv_highgui242.dll -lstdc++

--- a/opencv/cvaux.go
+++ b/opencv/cvaux.go
@@ -63,7 +63,7 @@ func (this *HaarCascade) DetectObjects(image *IplImage) []*Rect {
 	seq := C.cvHaarDetectObjects(unsafe.Pointer(image), this.cascade, storage, 1.1, 3, C.CV_HAAR_DO_CANNY_PRUNING, C.cvSize(0, 0), C.cvSize(0, 0))
 	var faces []*Rect
 	for i := 0; i < (int)(seq.total); i++ {
-		rect := (*Rect)((*_Ctype_CvRect)(unsafe.Pointer(C.cvGetSeqElem(seq, C.int(i)))))
+		rect := (*Rect)((*C.CvRect)(unsafe.Pointer(C.cvGetSeqElem(seq, C.int(i)))))
 		rectgc := NewRect(rect.X(), rect.Y(), rect.Width(), rect.Height())
 		faces = append(faces, &rectgc)
 	}


### PR DESCRIPTION
Mangled C names are no longer accepted as of Go 1.12: https://golang.org/doc/go1.12#cgo

Fixes: #129 